### PR TITLE
Check for parameters passed By Reference.

### DIFF
--- a/code/CNHDevelopmentTaskExample/CNH_DevelopmentTaskAssemblyTEST/TestingFrameworkMethods.cs
+++ b/code/CNHDevelopmentTaskExample/CNH_DevelopmentTaskAssemblyTEST/TestingFrameworkMethods.cs
@@ -53,7 +53,12 @@ namespace CNH_DevelopmentTaskAssemblyTEST
                         // Convert input to the appropriate type
                         try
                         {
-                            parameterValues[i] = Convert.ChangeType(input, parameters[i].ParameterType);
+                            Type parameterType = parameters[i].ParameterType;
+                            if (parameterType.IsByRef)
+                            {
+                                parameterType = parameterType.GetElementType();
+                            }
+                            parameterValues[i] = Convert.ChangeType(input, parameterType);
                         }
                         catch (Exception ex)
                         {

--- a/code/TestingFrameworkMethods.cs
+++ b/code/TestingFrameworkMethods.cs
@@ -47,7 +47,12 @@ namespace CNH_DevelopmentTaskAssemblyTEST
                         // Convert input to the appropriate type
                         try
                         {
-                            parameterValues[i] = Convert.ChangeType(input, parameters[i].ParameterType);
+                            Type parameterType = parameters[i].ParameterType;
+                            if (parameterType.IsByRef)
+                            {
+                                parameterType = parameterType.GetElementType();
+                            }
+                            parameterValues[i] = Convert.ChangeType(input, parameterType);
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
Ran into an issue when testing standard methods that pass parameters by reference (e.g. Infobar).
This change grabs the type being referenced by the parameter, if necessary.